### PR TITLE
fix: 커스텀 파일 확장자명이 중복된다면 예외를 발생

### DIFF
--- a/src/main/java/flow/practice/blockfileextentions/domain/exception/CustomFileExtensionDuplicatedException.java
+++ b/src/main/java/flow/practice/blockfileextentions/domain/exception/CustomFileExtensionDuplicatedException.java
@@ -1,0 +1,11 @@
+package flow.practice.blockfileextentions.domain.exception;
+
+import flow.practice.blockfileextentions.global.error.ErrorCode;
+import flow.practice.blockfileextentions.global.error.exception.BusinessException;
+
+public class CustomFileExtensionDuplicatedException extends BusinessException {
+
+    public CustomFileExtensionDuplicatedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/flow/practice/blockfileextentions/domain/repository/BlockedFileExtensionRepository.java
+++ b/src/main/java/flow/practice/blockfileextentions/domain/repository/BlockedFileExtensionRepository.java
@@ -7,9 +7,12 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BlockedFileExtensionRepository extends JpaRepository<BlockedFileExtension, Long> {
+
     List<BlockedFileExtension> findByIsFixedTrueAndDeletedAtIsNull();
 
     int countByIsFixedFalseAndDeletedAtIsNull();
 
     List<BlockedFileExtension> findByIsFixedFalseAndDeletedAtIsNull();
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/flow/practice/blockfileextentions/domain/service/BlockedFileExtensionService.java
+++ b/src/main/java/flow/practice/blockfileextentions/domain/service/BlockedFileExtensionService.java
@@ -4,6 +4,7 @@ import flow.practice.blockfileextentions.domain.dto.request.CustomExtensionNameR
 import flow.practice.blockfileextentions.domain.dto.response.CustomExtensionsResponseDto;
 import flow.practice.blockfileextentions.domain.dto.response.FixedExtensionsResponseDto;
 import flow.practice.blockfileextentions.domain.entity.BlockedFileExtension;
+import flow.practice.blockfileextentions.domain.exception.CustomFileExtensionDuplicatedException;
 import flow.practice.blockfileextentions.domain.exception.CustomFileExtensionOverMaxCountException;
 import flow.practice.blockfileextentions.domain.repository.BlockedFileExtensionRepository;
 import flow.practice.blockfileextentions.global.error.ErrorCode;
@@ -77,6 +78,13 @@ public class BlockedFileExtensionService {
                 if (customFileExtensionCount == 200) {
                     throw new CustomFileExtensionOverMaxCountException(
                         ErrorCode.CUSTOM_FILE_EXTENSION_OVER_MAX_COUNT_ERROR
+                    );
+                }
+
+                boolean alreadyExist = blockedFileExtensionRepository.existsByName(request.name());
+                if (alreadyExist) {
+                    throw new CustomFileExtensionDuplicatedException(
+                        ErrorCode.CUSTOM_FILE_EXTENSION_DUPLICATED_ERROR
                     );
                 }
 

--- a/src/main/java/flow/practice/blockfileextentions/global/error/ErrorCode.java
+++ b/src/main/java/flow/practice/blockfileextentions/global/error/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND_ERROR(404, "DB-001", "요청한 엔티티를 찾을 수 없습니다."),
 
     //blockedFileExtension
-    CUSTOM_FILE_EXTENSION_OVER_MAX_COUNT_ERROR(400, "BF-001", "커스텀 파일 확장자의 개수가 최대치를 초과했습니다.");
+    CUSTOM_FILE_EXTENSION_OVER_MAX_COUNT_ERROR(400, "BF-001", "커스텀 파일 확장자의 개수가 최대치를 초과했습니다."),
+    CUSTOM_FILE_EXTENSION_DUPLICATED_ERROR(400, "BF-002", "커스텀 파일 확장자명이 중복되었습니다.");
 
 
     private final int status;

--- a/src/test/java/flow/practice/blockfileextentions/service/BlockedFileExtensionServiceTest.java
+++ b/src/test/java/flow/practice/blockfileextentions/service/BlockedFileExtensionServiceTest.java
@@ -13,6 +13,7 @@ import flow.practice.blockfileextentions.domain.dto.request.CustomExtensionNameR
 import flow.practice.blockfileextentions.domain.dto.response.CustomExtensionsResponseDto;
 import flow.practice.blockfileextentions.domain.dto.response.FixedExtensionsResponseDto;
 import flow.practice.blockfileextentions.domain.entity.BlockedFileExtension;
+import flow.practice.blockfileextentions.domain.exception.CustomFileExtensionDuplicatedException;
 import flow.practice.blockfileextentions.domain.exception.CustomFileExtensionOverMaxCountException;
 import flow.practice.blockfileextentions.domain.repository.BlockedFileExtensionRepository;
 import flow.practice.blockfileextentions.domain.service.BlockedFileExtensionService;
@@ -151,7 +152,7 @@ class BlockedFileExtensionServiceTest {
     }
 
     @Test
-    @DisplayName("커스텀 확장자를 추가할 때 최대 개수보다 초가되면 오류가 발생한다.")
+    @DisplayName("커스텀 확장자를 추가할 때 최대 개수보다 초가되면 예외가 발생한다.")
     void addCustomExtensionOverMaxCount() {
         //given
         CustomExtensionNameRequestDto request = BlockedFileExtensionDtoFixture.customExtensionNameRequestDto();
@@ -161,9 +162,24 @@ class BlockedFileExtensionServiceTest {
 
         //when & then
         assertThatThrownBy(() -> blockedFileExtensionService.addCustomExtension(request))
-
             .isInstanceOf(CustomFileExtensionOverMaxCountException.class)
             .hasMessageContaining(
                 ErrorCode.CUSTOM_FILE_EXTENSION_OVER_MAX_COUNT_ERROR.getMessage());
+    }
+
+    @Test
+    @DisplayName("커스텀 확장자명이 중복되면 예외가 발생한다.")
+    void duplicatedCustomExtension() {
+        //given
+        CustomExtensionNameRequestDto request = BlockedFileExtensionDtoFixture.customExtensionNameRequestDto();
+        given(
+            blockedFileExtensionRepository.existsByName(request.name())
+        ).willReturn(true);
+
+        //when && then
+        assertThatThrownBy(() -> blockedFileExtensionService.addCustomExtension(request))
+            .isInstanceOf(CustomFileExtensionDuplicatedException.class)
+            .hasMessageContaining(
+                ErrorCode.CUSTOM_FILE_EXTENSION_DUPLICATED_ERROR.getMessage());
     }
 }


### PR DESCRIPTION
## 😋 작업한 내용

- 커스텀 파일 확장자명이 중복되었을 때 커스텀으로 예외를 처리하였습니다.

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #17 


---